### PR TITLE
Add new build step in CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,6 +29,9 @@ jobs:
 
     - name: Run eslint
       run: npm run lint
+      
+    - name: Build prisma client
+      run: npx prisma generate
 
     - name: Build TypeScript
       run: npm run build

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Run eslint
       run: npm run lint
       
-    - name: Build prisma client
+    - name: Generate prisma client
       run: npx prisma generate
 
     - name: Build TypeScript


### PR DESCRIPTION
Generate prisma client before the TypeScript code being built in CI so it does not throw `new TypeError` due to non-existing `GuildConfigs` type